### PR TITLE
Run the converter in small batches

### DIFF
--- a/converters/thankyou-like-g33k/converter.php
+++ b/converters/thankyou-like-g33k/converter.php
@@ -3,16 +3,31 @@ define('IN_MYBB', 1);
 require_once "../../inc/init.php";
 
 define('SIMPLELIKES_CONVERSION_SCRIPT', 'THANKYOU_LIKE_G33K');
+ini_set('max_execution_time', 300);
 
+$batch = 0;
+$total = 0;
 $newLikes = array();
+
 $query = $db->simple_select('g33k_thankyoulike_thankyoulike', '*');
 while ($like = $db->fetch_array($query)) {
     $newLikes[] = array(
         'post_id' => (int) $like['pid'],
         'user_id' => (int) $like['uid'],
     );
+
+	$batch++;
+	$total++;
+
+	if($batch == 1000) {
+		$db->insert_query_multiple('post_likes', $newLikes);
+
+		$newLikes = array();
+		$batch = 0;
+		echo "Converted {$total} old like(s) to Simple Likes<br/>";
+	}
 }
 
 $db->insert_query_multiple('post_likes', $newLikes);
 
-echo 'Converted '.count($newLikes).' old like(s) to Simple Likes';
+echo "Converted {$total} old like(s) to Simple Likes";


### PR DESCRIPTION
I have over 300,000 likes in my database so trying to convert them all in one go caused PHP to blow through its memory limit and the MySQL server to break (connection was dropped as soon as the query was sent, probably due to the size).
I rewrote it to insert likes in batches of 1,000 which it seemed to handle a lot nicer. I added the ini_set line as it still takes its time to run, although I'd hope that anyone with a similar-sized database runs it from the CLI :stuck_out_tongue: 
