### PR TITLE
Fixed mark read and added post subject

### DIFF
--- a/inc/languages/english/simplelikes.lang.php
+++ b/inc/languages/english/simplelikes.lang.php
@@ -3,7 +3,8 @@
 $l['simplelikes'] = 'SimpleLikes';
 
 $l['simplelikes_alert_setting'] = 'Receive alert when one of your posts is liked?';
-$l['simplelikes_alert'] = '{1} liked <a href="{2}">your post</a>. Others may have liked this post since.';
+$l['simplelikes_alert'] = '{1} liked your post <b>"{2}"</b>. Others may have liked this post since.';
+$l['simplelikes_alert_fallback'] = '{1} liked your post. Others may have liked this post since.';
 
 $l['simplelikes_like'] = 'Like';
 $l['simplelikes_unlike'] = 'Unlike';

--- a/inc/plugins/MybbStuff/SimpleLikes/src/LikeFormatter.php
+++ b/inc/plugins/MybbStuff/SimpleLikes/src/LikeFormatter.php
@@ -35,11 +35,20 @@ class MybbStuff_SimpleLikes_LikeFormatter extends MybbStuff_MyAlerts_Formatter_A
 		MybbStuff_MyAlerts_Entity_Alert $alert,
 		array $outputAlert
 	) {
-		return $this->lang->sprintf(
-			$this->lang->simplelikes_alert,
-			$outputAlert['from_user_profilelink'],
-			$this->buildShowLink($alert)
-		);
+		$alertContent = $alert->getExtraDetails();
+		if (isset($alertContent['subject'])) {
+			$message = $this->lang->sprintf(
+				$this->lang->simplelikes_alert,
+				$outputAlert['from_user'],
+				htmlspecialchars_uni($alertContent['subject'])
+			);
+		} else {
+			$message = $this->lang->sprintf(
+				$this->lang->simplelikes_alert_fallback,
+				$outputAlert['from_user']
+			);
+		}
+		return $message;
 	}
 
 	/**

--- a/inc/plugins/simplelikes.php
+++ b/inc/plugins/simplelikes.php
@@ -884,9 +884,8 @@ function simplelikesAjax()
 						$alert = new MybbStuff_MyAlerts_Entity_Alert($post['uid'], $alertType, $post['pid']);
 						$alert->setExtraDetails([
 							'tid' => (int)$post['tid'],
+							'subject' => $post['subject']
 						]);
-
-
 						$alertManager->addAlert($alert);
 					}
 				}


### PR DESCRIPTION
Fixed #32 
Fixed #35 

I think this is the best way to fix these 2 issues. MyAlerts already adds a link that set the alerts read, adding other links will override the existing link. I also added the subject to extra details and added a fallback language for alerts that doesn't have it.

![](https://image.ibb.co/chMs5p/immagine.png)